### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ MorphicDraw was created in Pharo (version 4). To load the code:
 Open the Monticello Browser. Add a new repository of type smalltalkhub.com. 
 The owner is StephanEggermont, the project is MorphicDraw. User and password are only needed
 when you want to commit changes to the repository. Open the repository and load the latest version of
-MorphicDraw.
+MorphicDraw. You may do this by loading the latest version of ConfigurationOfMorphicDraw with Monticello. Then open a Playground and DoIt: ConfigurationOfMorphicDraw load.
 
-The application can be started by opening a workspace and DoIt: MorphicDraw open.
+The application can be started by opening a Playground and DoIt: MorphicDraw open.
 
 The .tex file was compiled with xeLaTeX

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ui frameworks in Pharo, Polymorph, Glamour and Spec.
 
 ![Screenshot of MorphicDraw](https://github.com/StephanEggermont/MorphicDraw/blob/master/SimpleMorphicDrawWindow.png)
 
-##Contents:
+## Contents:
 - A Morphic Application with a Window
   - Using Polymorph
   - Using Glamour
@@ -25,7 +25,7 @@ ui frameworks in Pharo, Polymorph, Glamour and Spec.
 - Selections (work in progress)
 - Loading the code
 
-##Loading the code
+## Loading the code
 MorphicDraw was created in Pharo (version 4). To load the code:
 Open the Monticello Browser. Add a new repository of type smalltalkhub.com. 
 The owner is StephanEggermont, the project is MorphicDraw. User and password are only needed


### PR DESCRIPTION
Hi Stephan,
I had problems to load a Pharo application when there is a Configuration File in Monticello. I found no documentation on how to do, instead I tried to find it out myself. 

Is the change to the documentation I propose correct?
I also added two blanks so that the sub headings are correctly displayed.

BR
Rainer